### PR TITLE
corrections: 2026-07 batch (ap90, 15 changes, 2 issues) + repo docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ v02/krm/krm_etymology.jsonl
 v02/mw/mw_etymology.jsonl
 v02/pwg/pwg_etymology.jsonl
 v02/pw/pw_etymology.jsonl
+
+# machine-local IDE settings
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **csl-orig** is a Sanskrit Lexicon **data-store** repository — part of the Cologne Digital Sanskrit Lexicon (CDSL) infrastructure.
 
+## Dictionary Correction Safety
+
+`v02/<dict>/<dict>.txt` files are canonical dictionary sources. They may be
+changed only through the documented CDSL correction workflow: snapshot, apply via
+line-addressed change file or equivalent controlled edit, regenerate/validate,
+create the `csl-corrections` audit trail, and commit the paired repos.
+
+Before applying any old GitHub correction issue, search sibling `csl-corrections`
+CFR and batch history for the same dictionary, L number, headword, old text, and
+new text. If the registry says `No change`, rejected, deferred, or otherwise not
+to be applied, **do not patch** unless a maintainer explicitly reopens the
+decision.
+
+For accepted corrections, decide before editing whether the source should use a
+plain replacement or an inline correction layer such as
+`{{old->new||YYYYMMDD|author|issue|}}`, which preserves the original reading.
+
 ## Repo Category
 
 `data-store` — see the [tooling runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md) for category-specific conventions.


### PR DESCRIPTION
## 2026-07 CDSL correction batch

One consolidated monthly batch for `csl-orig`, per the batch discipline (queued via `/cologne-correction-queue`, shipped via `/cologne-batch-pr`). No direct pushes to the default branch — this topic branch + single PR is the sanctioned write.

### Summary

| Dict | Lines | Issue | Change | Validation |
|---|---:|---|---|---|
| ap90 | 14 | [AP90#14](https://github.com/sanskrit-lexicon/AP90/issues/14) | Residual paired-parens-outside-Devanagari `{#(X)#}` → `({#X#})` — the 14 instances the maintainer's prior 513-change pass on #14 missed | ✅ ET-parse |
| ap90 | 1 | [CORRECTIONS#434](https://github.com/sanskrit-lexicon/CORRECTIONS/issues/434) | Remove the duplicate, unbracketed `--Comp.` marker in *sarpis* (L29859, physical line 257097); SergeA verified against ed.3 (1924) | ✅ ET-parse |

**Total: 15 line changes in [`v02/ap90/ap90.txt`](https://github.com/sanskrit-lexicon/csl-orig/blob/batch/202607-corrections/v02/ap90/ap90.txt), line-count parity 273,715 → 273,715.**

### Validation

- `updateByLine.py` applied both change files against current `origin/main` HEAD cleanly (14/14 + 1/1, no relocation needed — line numbers still matched).
- `make_xml.py` full build: **"All records parsed by ET"** (34,882 entries), no ParseError. BOM check clean (first bytes `3c4c3e`). Validated in an **isolated build outdir** — `csl-orig` was not modified during validation.
- `xmllint` DTD validation not run locally (xmllint absent); the ET-parse is the primary structural check.
- Supersedes PR #2863 (which bundled these ap90 lines with unrelated already-shipped/duplicate `mw.txt`/`stc.txt` changes); this batch carries **only** the re-validated `ap90.txt` lines, re-located against current `main`.

Closes sanskrit-lexicon/AP90#14
Closes sanskrit-lexicon/CORRECTIONS#434

Audit trail (change files + per-change provenance readme) committed to [`csl-corrections`](https://github.com/sanskrit-lexicon/csl-corrections).

Prepared: Sonnet 5 (`claude-sonnet-5`) + Opus 4.8 (`claude-opus-4-8`), 11–12 Jul 2026. Shipped by Opus 4.8 (`claude-opus-4-8`). Maintainers merge on their own schedule — auto-merge intentionally OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Addendum, 04-08-2026 — repo-maintenance docs folded in

Two repo-maintenance files were added to this branch rather than opened as a separate pull request, to keep this repo's one-PR-per-month noise budget intact. **No dictionary text is touched by the addendum** (`+20` lines, `v02/` untouched):

| File | Change |
|---|---|
| [CLAUDE.md](https://github.com/sanskrit-lexicon/csl-orig/blob/main/CLAUDE.md) | +17 — new **Dictionary Correction Safety** section: `v02/<dict>/<dict>.txt` may change only through the documented CDSL workflow; search the [csl-corrections](https://github.com/sanskrit-lexicon/csl-corrections) CFR and batch history for the same dictionary / L-number / headword / old text before applying any old correction issue, and do not patch what the registry marked `No change`, rejected, or deferred; decide plain-replacement vs. inline `{{old->new\|\|YYYYMMDD\|author\|issue\|}}` layer before editing. |
| [.gitignore](https://github.com/sanskrit-lexicon/csl-orig/blob/main/.gitignore) | +3 — ignore machine-local `.claude/` IDE settings. |

These had been prepared on 05-07-2026 and deliberately left uncommitted in a local checkout, per this repo's rule that agents never push directly.

**A parked `README.md` rewrite from the same batch was deliberately excluded.** This branch already carries a later and fuller version of it — `Last updated: 11-07-2026` against the parked `05-07-2026`, with full blob URLs, all 45 dictionary directories linked, and the `docs/CORRECTION_MANUAL.md` pointer. Applying the parked copy would have been a net **−48 lines**, reverting a month of work off a stale base.

Addendum by Opus 5 (`claude-opus-5`), 04-08-2026. Auto-merge remains intentionally OFF.
