### PR TITLE
docs(claude): data-store runbook + H3044 freshness pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,46 +1,57 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+_Created: 14-06-2026 · Last updated: 16-08-2026_
 
-## Project Overview
+**csl-orig** is the Cologne Digital Sanskrit Dictionaries **data store**.
+Canonical digitised text lives at [`v02/<dict>/<dict>.txt`](https://github.com/sanskrit-lexicon/csl-orig/tree/main/v02)
+(SLP1, one record per `<L>`…`<LEND>`). It is not a generator and not a web
+frontend.
 
-**csl-orig** is a Sanskrit Lexicon **data-store** repository — part of the Cologne Digital Sanskrit Lexicon (CDSL) infrastructure.
+## What to run
 
-## Repo Category
+Agents **never commit** and **never push** this repository — not even a
+one-line dictionary fix. Prepare the change locally, XML-validate, then
+queue. Delivery is one consolidated PR at most ~monthly.
 
-`data-store` — see the [tooling runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md) for category-specific conventions.
+1. Express the edit as an `updateByLine.py` change file (UTF-8, **no BOM**):
+   ```
+   1234 old exact original line text here
+   1234 new exact replacement line text here
+   ```
+   `ins` inserts after; `del` deletes. `;` starts a comment.
+2. Validate XML **before** queueing (from sibling
+   [csl-pywork](https://github.com/sanskrit-lexicon/csl-pywork) `v02/`):
+   `sh generate_dict.sh <dict> tempparent/<dict>` then
+   `sh xmlchk_xampp.sh <dict>`. On Windows without XAMPP / `xmllint`,
+   [`make_xml.py`](https://github.com/sanskrit-lexicon/csl-pywork/blob/main/v02/makotemplates/pywork/make_xml.py)
+   printing `All records parsed by ET` is the validate signal.
+3. Park the validated change with
+   [`/cologne-correction-queue`](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-correction-queue.md).
+   Ship the monthly bundle with
+   [`/cologne-batch-pr`](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-batch-pr.md).
 
-## GitHub Issue Conventions
+The eight-stage snapshot → apply → regenerate → validate → audit sequence is
+documented once:
+[csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
+Do not invent a second workflow.
 
-This repository uses the **Cologne tooling-repo taxonomy**. All issues must have:
-- **Exactly one type label** (9 options)
-- **Exactly one severity label** (4 levels)
-- **One milestone** (5 options)
+## Do not
 
-### Type Labels
-- `bug` — Code defect (wrong output, broken contract)
-- `feature` — Net-new capability
-- `enhancement` — Improvement to existing capability
-- `performance` — Speed, memory, throughput optimization
-- `tech-debt` — Refactoring, cleanup, dependency updates
-- `security` — CVE, auth issue, credential exposure
-- `documentation` — Prose docs, API docs, comments
-- `infrastructure` — CI/CD, deploy, data pipelines, build tooling
-- `question` — Research, proposals, open discussions
+- Commit or push dictionary source under `v02/`.
+- Write files with `utf-8-sig` (a UTF-8 BOM). After a write:
+  `python -c "with open(f,'rb') as x: print(x.read(3).hex())"` must not start
+  `efbbbf`.
+- Comment on Cologne issues unless a human asked (maintainer-noise rule).
+- Treat `printchange.txt` as a digital/markup fix log — it records
+  deviations from the scanned print.
 
-### Severity Labels
-- `trivial` — Cosmetic, < 1 hour
-- `minor` — Single function/component
-- `major` — Multiple files, design decision
-- `critical` — Blocks users, data loss/security CVE
+## Primer
 
-### Milestones
-- **API Stability** — performance, security, regressions
-- **User Experience** — bugs, features, enhancements
-- **Data Quality** — data-pipeline issues, integrity
-- **Developer Experience** — tech-debt, infrastructure, docs
-- **Community** — questions, proposals, discussions
+Encodings, `key1`/`key2`, SLP1/IAST/Devanāgarī, and the broken
+`iast_to_devanagari` trap:
+[SANSKRIT_CONTEXT_PRIMER.md](https://github.com/gasyoun/github-spine/blob/main/SANSKRIT_CONTEXT_PRIMER.md).
 
-## Cross-Repo Coordination
+Issues use the Cologne taxonomy — see
+[`/cologne-issue-runbook`](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-issue-runbook.md).
 
-The org-level project [Tooling Roadmap](https://github.com/orgs/sanskrit-lexicon/projects/9) tracks tool work across all repositories.
+_Dr. Mārcis Gasūns_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,20 @@
 # CLAUDE.md
 
-_Created: 14-06-2026 · Last updated: 16-08-2026_
+_Created: 14-06-2026 · Last updated: 20-08-2026_
 
 **csl-orig** is the Cologne Digital Sanskrit Dictionaries **data store**.
 Canonical digitised text lives at [`v02/<dict>/<dict>.txt`](https://github.com/sanskrit-lexicon/csl-orig/tree/main/v02)
 (SLP1, one record per `<L>`…`<LEND>`). It is not a generator and not a web
 frontend.
 
-## What to run
+## How to run
 
-Agents **never commit** and **never push** this repository — not even a
+Agents **never commit or push dictionary source** under `v02/` — not even a
 one-line dictionary fix. Prepare the change locally, XML-validate, then
-queue. Delivery is one consolidated PR at most ~monthly.
+queue. Delivery is one consolidated source PR at most ~monthly.
+
+This file (`CLAUDE.md`) is a meta-doc, not dictionary text: land it via a
+GitHub PR, never a direct push to `main`.
 
 1. Express the edit as an `updateByLine.py` change file (UTF-8, **no BOM**):
    ```
@@ -37,13 +40,12 @@ Do not invent a second workflow.
 
 ## Do not
 
-- Commit or push dictionary source under `v02/`.
+- Commit or push dictionary source under `v02/` (the org fence on csl-orig).
 - Write files with `utf-8-sig` (a UTF-8 BOM). After a write:
   `python -c "with open(f,'rb') as x: print(x.read(3).hex())"` must not start
   `efbbbf`.
 - Comment on Cologne issues unless a human asked (maintainer-noise rule).
-- Treat `printchange.txt` as a digital/markup fix log — it records
-  deviations from the scanned print.
+- Treat csl-corrections [`<dict>_printchange.txt`](https://github.com/sanskrit-lexicon/csl-corrections) as a digital/markup fix log — it records deviations from the scanned print. Those files are not in this repo.
 
 ## Primer
 
@@ -51,7 +53,11 @@ Encodings, `key1`/`key2`, SLP1/IAST/Devanāgarī, and the broken
 `iast_to_devanagari` trap:
 [SANSKRIT_CONTEXT_PRIMER.md](https://github.com/gasyoun/github-spine/blob/main/SANSKRIT_CONTEXT_PRIMER.md).
 
-Issues use the Cologne taxonomy — see
+Issues: this repo is a **data-store** in the
+[tooling runbook](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/runbook/cologne-tooling-runbook.md)
+(types `bug` / `feature` / `infrastructure` / …). Digitisation issues that
+still land here (`link-target`, `text-correction`, `encoding`, …) use
 [`/cologne-issue-runbook`](https://github.com/gasyoun/claude-config/blob/main/commands/cologne-issue-runbook.md).
+Live labels mix both; do not recopy either table into this file.
 
 _Dr. Mārcis Gasūns_


### PR DESCRIPTION
## Meta-doc only — not a dictionary text correction

This PR changes only `CLAUDE.md`. It does **not** touch `v02/` source text.

The org fence on csl-orig (no agent direct commits/PRs) targets **dictionary source** under `v02/`. Agent instructions in this file are a meta-doc: they land via PR, never a direct push to `main`.

## What changed

- Dated header `_Created: 14-06-2026 · Last updated: 20-08-2026_` (H3044 / H2816 14-day SLA).
- Replaced the recopied tooling-taxonomy stub on `main` with a data-store runbook (H2821).
- Fence wording: never commit/push `v02/`; this file via PR.
- Taxonomy: csl-orig is a **data-store** in the tooling runbook; digitisation types that still land here use `/cologne-issue-runbook`. Live labels mix both. Do not recopy either table.
- `printchange` logs live in csl-corrections as `<dict>_printchange.txt`, not in this repo.

## Links

- [H3044](https://github.com/gasyoun/Uprava/blob/main/handoffs/H3044-Grok_csl-orig_claude-md-refresh_17.08.26.md)
- [H2821](https://github.com/gasyoun/Uprava/blob/main/handoffs/archive/H2821-Grok_Uprava_dict-pipeline-claude-fill_15.08.26.md)
