### PR TITLE
docs(claude): document CI workflows in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-_Created: 14-06-2026 · Last updated: 20-08-2026_
+_Created: 14-06-2026 · Last updated: 26-08-2026_
 
 **csl-orig** is the Cologne Digital Sanskrit Dictionaries **data store**.
 Canonical digitised text lives at [`v02/<dict>/<dict>.txt`](https://github.com/sanskrit-lexicon/csl-orig/tree/main/v02)
@@ -37,6 +37,25 @@ The eight-stage snapshot → apply → regenerate → validate → audit sequenc
 documented once:
 [csl-corrections/docs/correction-workflow.md](https://github.com/sanskrit-lexicon/csl-corrections/blob/main/docs/correction-workflow.md).
 Do not invent a second workflow.
+
+## CI
+
+[`.github/workflows/`](https://github.com/sanskrit-lexicon/csl-orig/tree/main/.github/workflows)
+— none of these jobs edit dictionary source in this repo:
+
+1. **encoding-guard** — BOM / invalid-UTF-8 gate
+   ([`scripts/check_encoding.py`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/scripts/check_encoding.py));
+   fires on any push/PR touching `v02/**/*.txt`. A red run means the source
+   bytes are broken — fix locally, never patch on `main`.
+2. **Generate Dictionary** — manual (`workflow_dispatch`) per-dictionary
+   regeneration through csl-pywork templates; uploads `pywork/` + `web/`
+   artifacts.
+3. **Regenerate hwnorm1.sqlite** — weekly (Sun 05:00 UTC) or manual.
+4. **Generate and Sync Stardict Files** — when `v02/**` lands on `main`,
+   rebuilds and syncs StarDict files downstream
+   ([cologne-stardict](https://github.com/sanskrit-lexicon/cologne-stardict),
+   [stardict-sanskrit](https://github.com/indic-dict/stardict-sanskrit)).
+5. Dependabot PRs auto-merge when green.
 
 ## Do not
 


### PR DESCRIPTION
## What

Adds a **CI** section to \CLAUDE.md\ (meta-doc only — no file under \02/\ is touched) and bumps the Last-updated header date. Every claim was verified against the workflow files on this branch:

- **encoding-guard** — BOM / invalid-UTF-8 gate via \scripts/check_encoding.py\, fires on push/PR touching \02/**/*.txt\
- **Generate Dictionary** — manual \workflow_dispatch\ per-dictionary regeneration (csl-pywork templates, pywork/web artifacts)
- **Regenerate hwnorm1.sqlite** — weekly cron (Sun 05:00 UTC) + manual
- **Generate and Sync Stardict Files** — rebuilds + syncs downstream (\cologne-stardict\, \indic-dict/stardict-sanskrit\) when \02/**\ lands on \main\
- Dependabot PRs auto-merge when green

## Why

The freshness pass (H3367) requires CLAUDE.md to cover how-to-run / key files / CI / conventions. The 20-08 refresh covered everything except CI; agents touching dictionary bytes otherwise learn about the encoding-guard only after a red run.

## Fence ruling (H3367 Step 0)

The AGENTS.md danger fact 'no direct commits/PRs' was written for **dictionary-text corrections**, which indeed go only through the queued monthly batch path. Docs/meta changes have landed on csl-orig four times by precedent: 76dd471 (2026-05-06), 2e0e0f4 + a3e7aee (2026-05-15), and ac7e82f (2026-08-20, explicitly labeled 'Meta-doc only'). This PR continues that docs-only PR path; nothing under \02/\ changes, so encoding-guard does not fire.