### PR TITLE
fix(hooks): gate check_generate_dict.sh on pipeline exit status (G1, H3631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- **G1 hook gate (H3631):** `scripts/check_generate_dict.sh` now gates on the
+  `generate_dict.sh` pipeline EXIT STATUS as the primary verdict, and the
+  `|| true` that discarded the pipeline status is gone — a pipeline dying with
+  no red output can no longer pass as "OK: no red lines" (O1). Red lines
+  remain as a secondary diagnostic channel (failures are printed, stripped of
+  ANSI codes, together with the failing status).
+
 ## [0.1.0] - 2026-06-30
 
 ### Added

--- a/scripts/check_generate_dict.sh
+++ b/scripts/check_generate_dict.sh
@@ -66,20 +66,36 @@ for dict in "${dicts[@]}"; do
 
     # Run the full pipeline; capture stdout+stderr (ANSI codes are always
     # emitted by generate_dict.sh regardless of tty status).
-    pipeline_output=$(cd "$PYWORK_V02" && sh generate_dict.sh "$dict" "$outdir_rel" 2>&1) || true
+    # O1 fix: the pipeline EXIT STATUS is the primary gate — the previous
+    # '|| true' discarded it, so a pipeline dying with no red output passed
+    # as "OK: no red lines".
+    pipeline_output=$(cd "$PYWORK_V02" && sh generate_dict.sh "$dict" "$outdir_rel" 2>&1)
+    pipeline_status=$?
 
-    # Detect red lines: generate_dict.sh marks errors with \033[31m ... \033[0m
+    # Red lines remain a secondary diagnostic channel: generate_dict.sh marks
+    # errors with \033[31m ... \033[0m (O2 makes every failure channel red).
     red_lines=$(printf '%s\n' "$pipeline_output" | grep -F $'\033[31m' || true)
 
-    if [ -n "$red_lines" ]; then
-        echo "FAIL: generate_dict.sh produced error (red) output for '$dict':"
+    if [ $pipeline_status -ne 0 ]; then
+        echo "FAIL: generate_dict.sh exited with status $pipeline_status for '$dict':"
         echo "------"
         # Strip ANSI codes for cleaner display in pre-commit's output
+        printf '%s\n' "$pipeline_output" | sed $'s/\033\\[[0-9;]*m//g' | tail -40
+        echo "------"
+        if [ -n "$red_lines" ]; then
+            echo "Error (red) lines detected:"
+            printf '%s\n' "$red_lines" | sed $'s/\033\\[[0-9;]*m//g'
+            echo "------"
+        fi
+        overall_exit=1
+    elif [ -n "$red_lines" ]; then
+        echo "FAIL: generate_dict.sh produced error (red) output for '$dict':"
+        echo "------"
         printf '%s\n' "$red_lines" | sed $'s/\033\\[[0-9;]*m//g'
         echo "------"
         overall_exit=1
     else
-        echo "OK: no red lines for '$dict'."
+        echo "OK: pipeline exit 0, no red lines for '$dict'."
     fi
 done
 


### PR DESCRIPTION
**G1 (O1) of the H3487 adversarial audit** (Uprava H3631). Companion to the csl-pywork fail-closed pipeline PR.

## Fix

`scripts/check_generate_dict.sh`:

- **O1** — the `|| true` on the pipeline invocation discarded `generate_dict.sh`'s exit status, so a pipeline dying with **no** ANSI-red output yielded "OK: no red lines" and the commit passed with nothing validated. The pipeline **exit status** is now the primary gate; `|| true` is gone.
- Red lines remain a secondary diagnostic; on failure the script prints the failing status plus the (ANSI-stripped) pipeline tail and any red lines.
- **O2** is closed on the csl-pywork side: every failure channel in `generate_dict.sh` (including `cd` errors and the postxml/downloads stages) now prints a red STOP line, so this grep can no longer miss anything.

## Evidence

| Scenario | Old hook | New hook |
|---|---|---|
| Synthetic pipeline: `exit 7`, no output (O1's exact hole) | "OK: no red lines", **exit 0 — commit passes with nothing validated** | "FAIL: generate_dict.sh exited with status 7", **exit 1** |
| Injected malformed record in `v02/mci/mci.txt`, real pre-commit hook wired, real `git commit` | — | **commit rejected**, no commit landed |

The injected-record rejection is end-to-end: csl-pywork pipeline (fail-closed, companion PR) -> `redo_xml.sh` STOP -> `generate_dict.sh` exit 1 -> this hook FAIL -> pre-commit exit 1.
