### PR TITLE
reorg: delete broken reorg1.sh/reorg1_all.sh, tombstone in README (H3640)

### DIFF
--- a/reorg/README.txt
+++ b/reorg/README.txt
@@ -1,4 +1,8 @@
 
+TOMBSTONE 29-08-2026: reorg1.sh and reorg1_all.sh (deleted; see git history and PR for H3640) automated the
+v00/csl-data -> v02/ reorganization described below, which completed years ago; the scripts were broken as shipped
+(${dictlo^^} dies under sh, cd ../ assumed cwd=reorg/, and their v00/csl-data source no longer exists), so they are removed.
+
 11-04-2019
 This describes a reorganization of the csl-orig repository.
 For each dictionary xxx, there are two important data files:

--- a/reorg/reorg1.sh
+++ b/reorg/reorg1.sh
@@ -1,8 +1,0 @@
-dictlo=$1 # assume lower case
-dictup=${dictlo^^}  # upper case
-cd ../  # to toplevel csl-orig
-mkdir $dictlo
-origdir="v00/csl-data/${dictup}Scan/2020/orig"
-mv $origdir/${dictlo}.txt $dictlo/
-mv $origdir/hwextra/${dictlo}_hwextra.txt $dictlo/
-

--- a/reorg/reorg1_all.sh
+++ b/reorg/reorg1_all.sh
@@ -1,8 +1,0 @@
-for dictlo in  acc ae ap90 ben   bhs bop bor bur cae \
- ccs gra gst ieg inm  krm mci md mw mw72 \
- mwe pe pgn pui    pw pwg sch shs skd \
- snp stc vcp vei wil  yat
-do
- echo "reorganizing dictionary $dictlo"
- sh reorg1.sh $dictlo
-done


### PR DESCRIPTION
## Summary
- Deletes \eorg/reorg1.sh\ + \eorg/reorg1_all.sh\: broken as shipped, no live scenario. Deletion reversible via git history; nothing else removed.
- Leaves a tombstone in \eorg/README.txt\ recording what the scripts did and that the reorg is complete.

## Verified live on current tip (5810603) — memo O8/O9 protocol (H3487 adversarial audit §6b/§9)
- **O8 fixed-not-fixed: still-open → resolved by deletion.** \/bin/sh reorg1.sh mw\ → \\: bad substitution\ on every iteration (34 dicts via \eorg1_all.sh\).
- **O9: still-open → resolved by deletion.** \cd ../\ from any cwd other than \eorg/\ escapes to the repo's **parent** (demonstrated: landed in \GitHub/\, not repo root).
- **Missing source:** \00/csl-data/<DICT>Scan/2020/orig/<dict>.txt\ no longer exists in-tree (\ls v00/csl-data\ → No such file or directory); script also continues silently past its own errors (no \set -e\).
- Fix-instead rejected: the reorg these scripts automate completed in 5e0f026 (2019-11-04); no org member or history names a live scenario.

Refs: H3640 (gap spec G10 of H3487 audit)