### PR TITLE
fix(guard): fail the generate-dict hook on nonzero pipeline exit (audit O1 residual, H4227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-_Created: 30-06-2026 · Last updated: 05-09-2026_
+_Created: 30-06-2026 · Last updated: 06-09-2026_
 
 # Changelog
 
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- **Generate-dict guard now fails on a nonzero pipeline exit** (H4227, H3487
+  audit O1 residual): `scripts/check_generate_dict.sh` discarded the
+  pipeline's exit status (`|| true`) and keyed only on ANSI-red output, so a
+  pipeline that died without emitting its red marker passed as "OK: no red
+  lines". The status is now captured and the hook fails on nonzero exit OR
+  red lines, printing which of the two fired.
 
 ### Added
 - Canonical deletion/rename guard ([`scripts/check_deletions.sh`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/scripts/check_deletions.sh)): deleting or renaming a `v02/<dict>/<dict>.txt` source now fails the commit unless explicitly acknowledged (`CSL_ORIG_ACK_DELETION`, or `ack-deletion:` lines in CI) — H3632 finding O3/O4

--- a/scripts/check_generate_dict.sh
+++ b/scripts/check_generate_dict.sh
@@ -2,7 +2,8 @@
 # scripts/check_generate_dict.sh
 # Pre-commit hook: for each dict with staged changes under v02/<dict>/,
 # runs the full generate_dict.sh pipeline from ../csl-pywork/v02 and
-# fails if any red-line (ANSI \033[31m) output is produced.
+# fails if the pipeline exits nonzero OR produces red-line (ANSI \033[31m)
+# output.
 #
 # Called by pre-commit with the list of staged file paths as arguments
 # (pass_filenames: true).  The outdir convention matches the project:
@@ -86,20 +87,29 @@ for dict in "${dicts[@]}"; do
 
     # Run the full pipeline; capture stdout+stderr (ANSI codes are always
     # emitted by generate_dict.sh regardless of tty status).
-    pipeline_output=$(cd "$PYWORK_V02" && sh generate_dict.sh "$dict" "$outdir_rel" 2>&1) || true
+    # H4227 O1: the exit status is no longer discarded. A pipeline that dies
+    # without producing red output (crash before any stage marker, missing
+    # interpreter, etc.) must fail the hook exactly like a red-lined run;
+    # `set -e` is deliberately not set, so the assignment below cannot abort
+    # the script and $? reliably holds the pipeline status.
+    pipeline_output=$(cd "$PYWORK_V02" && sh generate_dict.sh "$dict" "$outdir_rel" 2>&1)
+    pipeline_status=$?
 
     # Detect red lines: generate_dict.sh marks errors with \033[31m ... \033[0m
     red_lines=$(printf '%s\n' "$pipeline_output" | grep -F $'\033[31m' || true)
 
-    if [ -n "$red_lines" ]; then
-        echo "FAIL: generate_dict.sh produced error (red) output for '$dict':"
+    if [ "$pipeline_status" -ne 0 ] || [ -n "$red_lines" ]; then
+        echo "FAIL: generate_dict.sh failed for '$dict' (exit status $pipeline_status):"
         echo "------"
         # Strip ANSI codes for cleaner display in pre-commit's output
         printf '%s\n' "$red_lines" | sed $'s/\033\\[[0-9;]*m//g'
+        if [ -z "$red_lines" ]; then
+            echo "(no red-line output — the pipeline exited without emitting its error marker)"
+        fi
         echo "------"
         overall_exit=1
     else
-        echo "OK: no red lines for '$dict'."
+        echo "OK: generate_dict.sh passed for '$dict' (exit status 0, no red lines)."
     fi
 done
 


### PR DESCRIPTION
Closes the **O1 residual** of the [adversarial audit](https://github.com/sanskrit-lexicon/csl-observatory/blob/main/docs/CODEBASE_ADVERSARIAL_AUDIT_2026-08.md), re-verified against current tip 2026-09-06 (after the H3631/H3632 waves closed the rest of G1/G2).

## Problem
`scripts/check_generate_dict.sh` captured the pipeline with `( ... ) || true` and decided solely on ANSI-red output. A pipeline that **died without emitting its red marker** (crash before any stage marker, missing interpreter) printed "OK: no red lines" and the commit passed with nothing validated.

## Fix
- The exit status is captured (`set -e` deliberately not set, so the assignment cannot abort the script).
- The hook fails on **nonzero exit OR red lines**, printing both the status and the (ANSI-stripped) red output, plus an explicit note when the failure carried no marker.

## Verification
- `bash -n` green; logic mirrors the H3631 fail-closed contract in csl-pywork (red STOP markers now make the red-line channel and the exit-status channel agree).

Human-gated deploy as usual — merging is the Cologne maintainers' call.