### PR TITLE
docs(claude): document guard-backstop workflow (H4575)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-_Created: 14-06-2026 · Last updated: 26-08-2026_
+_Created: 14-06-2026 · Last updated: 12-09-2026_
 
 **csl-orig** is the Cologne Digital Sanskrit Dictionaries **data store**.
 Canonical digitised text lives at [`v02/<dict>/<dict>.txt`](https://github.com/sanskrit-lexicon/csl-orig/tree/main/v02)
@@ -45,17 +45,23 @@ Do not invent a second workflow.
 
 1. **encoding-guard** — BOM / invalid-UTF-8 gate
    ([`scripts/check_encoding.py`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/scripts/check_encoding.py));
-   fires on any push/PR touching `v02/**/*.txt`. A red run means the source
-   bytes are broken — fix locally, never patch on `main`.
-2. **Generate Dictionary** — manual (`workflow_dispatch`) per-dictionary
+   fires on any push/PR touching `v02/**/*.txt` or the guard script itself. A
+   red run means the source bytes are broken — fix locally, never patch on
+   `main`.
+2. **guard-backstop** — CI mirror of the opt-in `.githooks/pre-commit` guard
+   (install once per clone with `scripts/install-hooks.sh`): full-tree
+   encoding scan, canonical deletion/rename guard (override only with an
+   `ack-deletion <L>` token in the commit message or PR body), and a
+   `generate_dict` pipeline run per touched dictionary.
+3. **Generate Dictionary** — manual (`workflow_dispatch`) per-dictionary
    regeneration through csl-pywork templates; uploads `pywork/` + `web/`
    artifacts.
-3. **Regenerate hwnorm1.sqlite** — weekly (Sun 05:00 UTC) or manual.
-4. **Generate and Sync Stardict Files** — when `v02/**` lands on `main`,
+4. **Regenerate hwnorm1.sqlite** — weekly (Sun 05:00 UTC) or manual.
+5. **Generate and Sync Stardict Files** — when `v02/**` lands on `main`,
    rebuilds and syncs StarDict files downstream
    ([cologne-stardict](https://github.com/sanskrit-lexicon/cologne-stardict),
    [stardict-sanskrit](https://github.com/indic-dict/stardict-sanskrit)).
-5. Dependabot PRs auto-merge when green.
+6. Dependabot PRs auto-merge when green.
 
 ## Do not
 


### PR DESCRIPTION
_Created: 12-09-2026 · Last updated: 12-09-2026_

## Description
H4575 CLAUDE.md truth refresh (STALE_17d, H2816 SLA 14d). Re-verified every claim vs the live clone; one real drift found and fixed:

- **guard-backstop.yml documented** — the CI mirror of the opt-in `.githooks/pre-commit` guard landed earlier but was never in the CI list; now documented with its three stages (full-tree encoding scan, canonical deletion/rename guard with the `ack-deletion <L>` override token, per-dict `generate_dict` pipeline run).
- encoding-guard trigger precision: also fires on `scripts/check_encoding.py` itself, not only `v02/**/*.txt`.
- Header date bumped 26-08-2026 → 12-09-2026.

## Type of change
- [x] Documentation update

## Related issues
H4575 (Uprava handoff, OxAlpha drain)

## Verification (all PASS)
- All 6 workflow YAMLs re-read; documented triggers match live cron/paths (`0 5 * * 0` Sun 05:00 UTC hwnorm1; `workflow_dispatch` generate-dict; push-to-`main` `v02/**` stardict).
- All 13 outbound link targets verified alive: 8 via sibling clones (csl-pywork `generate_dict.sh`/`xmlchk_xampp.sh`/`make_xml.py`/`updateByLine.py`, csl-corrections workflow doc, 3 claude-config commands, github-spine primer), 5 via `gh api` (csl-observatory runbook 29 KB, cologne-stardict, stardict-sanskrit, csl-corrections, csl-pywork).
- Write gates: no BOM (`232043`), valid UTF-8, 4,631 chars ≈ 1,157 tok ≪ 4,000-tok non-hub cap.
- `v02/` untouched — docs-only diff (+13/−7, CLAUDE.md only).

## Testing
- [x] Tested locally (claim re-verification against live clone)
- [x] Existing tests pass (encoding-guard / BOM gates run on this PR's CI)

## Checklist
- [x] Code follows the project style guidelines
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Commit message(s) are clear and concise

_Dr. Mārcis Gasūns_