### PR TITLE
rescue(E007/H4872): H4227 audit-O1 — generate-dict hook fails on nonzero pipeline exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-_Created: 30-06-2026 · Last updated: 05-09-2026_
+_Created: 30-06-2026 · Last updated: 06-09-2026_
 
 # Changelog
 
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- **Generate-dict guard now fails on a nonzero pipeline exit** (H4227, H3487
+  audit O1 residual): `scripts/check_generate_dict.sh` discarded the
+  pipeline's exit status (`|| true`) and keyed only on ANSI-red output, so a
+  pipeline that died without emitting its red marker passed as "OK: no red
+  lines". The status is now captured and the hook fails on nonzero exit OR
+  red lines, printing which of the two fired.
 
 ### Added
 - Canonical deletion/rename guard ([`scripts/check_deletions.sh`](https://github.com/sanskrit-lexicon/csl-orig/blob/main/scripts/check_deletions.sh)): deleting or renaming a `v02/<dict>/<dict>.txt` source now fails the commit unless explicitly acknowledged (`CSL_ORIG_ACK_DELETION`, or `ack-deletion:` lines in CI) — H3632 finding O3/O4

--- a/scripts/check_generate_dict.sh
+++ b/scripts/check_generate_dict.sh
@@ -2,7 +2,8 @@
 # scripts/check_generate_dict.sh
 # Pre-commit hook: for each dict with staged changes under v02/<dict>/,
 # runs the full generate_dict.sh pipeline from ../csl-pywork/v02 and
-# fails if any red-line (ANSI \033[31m) output is produced.
+# fails if the pipeline exits nonzero OR produces red-line (ANSI \033[31m)
+# output.
 #
 # Called by pre-commit with the list of staged file paths as arguments
 # (pass_filenames: true).  The outdir convention matches the project:
@@ -86,20 +87,29 @@ for dict in "${dicts[@]}"; do
 
     # Run the full pipeline; capture stdout+stderr (ANSI codes are always
     # emitted by generate_dict.sh regardless of tty status).
-    pipeline_output=$(cd "$PYWORK_V02" && sh generate_dict.sh "$dict" "$outdir_rel" 2>&1) || true
+    # H4227 O1: the exit status is no longer discarded. A pipeline that dies
+    # without producing red output (crash before any stage marker, missing
+    # interpreter, etc.) must fail the hook exactly like a red-lined run;
+    # `set -e` is deliberately not set, so the assignment below cannot abort
+    # the script and $? reliably holds the pipeline status.
+    pipeline_output=$(cd "$PYWORK_V02" && sh generate_dict.sh "$dict" "$outdir_rel" 2>&1)
+    pipeline_status=$?
 
     # Detect red lines: generate_dict.sh marks errors with \033[31m ... \033[0m
     red_lines=$(printf '%s\n' "$pipeline_output" | grep -F $'\033[31m' || true)
 
-    if [ -n "$red_lines" ]; then
-        echo "FAIL: generate_dict.sh produced error (red) output for '$dict':"
+    if [ "$pipeline_status" -ne 0 ] || [ -n "$red_lines" ]; then
+        echo "FAIL: generate_dict.sh failed for '$dict' (exit status $pipeline_status):"
         echo "------"
         # Strip ANSI codes for cleaner display in pre-commit's output
         printf '%s\n' "$red_lines" | sed $'s/\033\\[[0-9;]*m//g'
+        if [ -z "$red_lines" ]; then
+            echo "(no red-line output — the pipeline exited without emitting its error marker)"
+        fi
         echo "------"
         overall_exit=1
     else
-        echo "OK: no red lines for '$dict'."
+        echo "OK: generate_dict.sh passed for '$dict' (exit status 0, no red lines)."
     fi
 done
 


### PR DESCRIPTION
E007 rescue drain (H4872, 15-09-2026). One local-only commit on the Windows box's clone was never pushed:

`5801badf13 fix(guard): fail the generate-dict hook on nonzero pipeline exit (H4227, audit O1)` — scripts/check_generate_dict.sh (+5/−15) + CHANGELOG.md.

Blob check: the remote's newest commit for scripts/check_generate_dict.sh is abb58edc (29-08-2026, H3632) — *older* than this commit (06-09-2026), so the fix is absent upstream (Uprava reports/RESCUE_14.09.26/CONTENT_CHECK_15.09.26.txt).

H4227 itself is closed ✅; this O1 item appears to have landed only in the local clone. Branch kept for preservation; do not delete until merged.